### PR TITLE
scraper: UK Parliament groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ What this is missing:
 
 `ukparl_ministers` fetches PDFs from [gov.uk list of ministers interests](https://www.gov.uk/government/publications/list-of-ministers-interests). They are stored in `MEMORIOUS_BASE_PATH/scraped_files/ukparl_ministers`.
 
+`ukparl_groups` gets the [All-Party Parliamentary Groups](https://publications.parliament.uk/pa/cm/cmallparty/200408/contents.htm) and for each benefit registered for a group, creates a declaration for each member of the group in the 'other' category, with the note "via role as {} in the {} All-Party Parliamentary Group" added to the `description`.
+
+Note: Politician membership of groups that have no benefits declared do not get recorded.
+
+`ukparl_groups` table columns:
+
+* `source`: url of the page the data came from
+* `disclosure_date`: date the benefit was registered
+* `body_received_by`: "UK Parliament"
+* `member_name`: name of the group member
+* `member_party`: political party of the group member
+* `interest_type`: "other"
+* `interest_date`: date the benefit was received
+* `interest_from`: the source of the benefit (which may be a person or organisation)
+* `interest_value`: value of the benefit 
+* `description`: the text content of one interest declared.
+
 ### Greater London Assembly
 
 Two scrapers, one to fetch the gifts/hospitality, and one for the declarations themselves.

--- a/oroi-scrape/config/ukparl_groups.yml
+++ b/oroi-scrape/config/ukparl_groups.yml
@@ -1,0 +1,39 @@
+name: ukparl_groups
+description: 'UK Parliament All-Party Parliamentary Groups interest registers'
+
+pipeline:
+
+  init:
+    method: seed
+    params:
+      url: https://publications.parliament.uk/pa/cm/cmallparty/200408/contents.htm
+    handle:
+      pass: fetch
+
+  fetch:
+    method: fetch
+    handle:
+      pass: list
+
+  list:
+    method: parse
+    params:
+      include_paths: 
+       - './/div[@id="mainTextBlock"]/ul'
+    handle:
+      fetch: group
+
+  group:
+    method: fetch
+    handle:
+      pass: parse
+
+  parse:
+    method: scrapers.ukparl:parse_group
+    handle:
+      pass: store
+
+  store:
+    method: db
+    params:
+      table: ukparl_groups

--- a/oroi-scrape/scrapers/ukparl.py
+++ b/oroi-scrape/scrapers/ukparl.py
@@ -39,3 +39,127 @@ def parse_twfy_xml(context, data):
                         declaration["description"] = "\n".join(item.itertext())
 
                         context.emit(data=declaration)
+
+"""
+ukparl_groups
+Parses the contents of the group pages
+"""
+def parse_group(context, data):
+    declaration = {}
+
+    with context.http.rehash(data) as result:
+        if result.html is not None:
+            content = result.html.findall(".//div[@id='mainTextBlock']//table")
+
+            group_name = result.html.find(".//div[@id='mainTextBlock']/h1/span").text_content()
+
+            benefits_in_kind = None
+            for table in content:
+                rows = table.findall(".//tr")
+                row_header = rows[0].text_content().strip().lower()
+                if row_header == "officers":
+                    officers = parse_group_officers(table)
+
+                # TODO: does this table ever contain data or is it actually just 
+                #       a subheading?
+                # if row_header == "registrable benefits received by the group":
+                #     benefits = parse_group_benefits(table)
+
+                if row_header == "benefits in kind":
+                    benefits_in_kind = parse_group_benefits_in_kind(table)
+
+            declaration_base = {
+                "source": result.url,
+                "body_received_by": "UK Parliament",
+                "interest_type": "other"
+            }
+
+            if benefits_in_kind is not None and len(benefits_in_kind) > 0:
+                for benefit in benefits_in_kind:
+                    declaration_benefit = copy.deepcopy(declaration_base)
+                    for field in benefit.keys():
+                        declaration_benefit[field] = benefit[field]
+
+                    for officer in officers:
+                        declaration = copy.deepcopy(declaration_benefit)
+                        declaration["member_name"] = officer["name"]
+                        declaration["member_party"] = officer["party"]
+
+                        membership_string = "via role as {} in the {} All-Party Parliamentary Group".format(officer["role"], group_name)
+
+                        declaration["description"] = "{} - {}".format(declaration_benefit["description"], membership_string)
+
+                        if len(declaration) > 0:
+                            context.emit(data=declaration)
+
+
+"""
+ukparl_groups
+Parses the Officers table
+"""
+def parse_group_officers(table):
+    officers = []
+    for row in table.findall(".//tr"):
+        cols = row.findall(".//td")
+        if len(cols) == 3:
+            officer = {}
+            if cols[0].text_content().strip() != "Role":
+                officer["role"] = cols[0].text_content().strip()
+
+            if cols[1].text_content().strip() != "Name":
+                officer["name"] = cols[1].text_content().strip()
+
+            if cols[2].text_content().strip() != "Party":
+                officer["party"] = cols[2].text_content().strip()
+
+            if len(officer) > 0:
+                officers.append(officer)
+
+    return officers
+
+"""
+ukparl_groups
+Parses the Registrable benefits table
+TODO: find an example of one that is actually filled in, so we know
+      what the headers are.. otherwise can't parse this (this might
+      not really be a data table though)
+"""
+def parse_group_benefits(table):
+    return []
+
+"""
+ukparl_groups
+Parses the Benefits In Kind table
+"""
+def parse_group_benefits_in_kind(table):
+    
+    headings = {
+        "0": "Source",
+        "1": "Description",
+        "2": "Value£sInbandsof£1,500",
+        "3": "Received",
+        "4": "Registered"
+    }
+
+    fields = {
+        "0": "interest_from",
+        "1": "description",
+        "2": "interest_value",
+        "3": "interest_date",
+        "4": "disclosure_date"
+    }
+
+    benefits_in_kind = []
+    for row in table.findall(".//tr"):
+        cols = row.findall(".//td")
+        
+        if len(cols) == 5:
+            benefit = {}
+            for i, col in enumerate(cols):
+                if col.text_content().strip().replace("\n", "").replace(" ", "") != headings.get(str(i)):
+                    benefit[fields[str(i)]] = col.text_content().strip()
+
+            if len(benefit) > 0:
+                benefits_in_kind.append(benefit)
+
+    return benefits_in_kind


### PR DESCRIPTION
gets the [All-Party Parliamentary Groups](https://publications.parliament.uk/pa/cm/cmallparty/200408/contents.htm) and for each benefit registered for a group, creates a declaration for each member of the group in the 'other' category, with the note "via role as {} in the {} All-Party Parliamentary Group" added to the `description`. Membership of groups with no registered benefits are not stored.